### PR TITLE
Feature/auto letsencrypt persist

### DIFF
--- a/docker-compose-prod/docker-compose.yaml
+++ b/docker-compose-prod/docker-compose.yaml
@@ -6,8 +6,6 @@ services:
       context: ./nginx-uwsgi-py3
       args:
         GIT_URI: ${GIT_URI}
-        SSL_DOMAIN: ${SSL_DOMAIN}
-        SSL_EMAIL: ${SSL_EMAIL}
     ports:
       - "80:80"
       - "443:443"
@@ -23,6 +21,8 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASS}
+      SSL_DOMAIN: ${SSL_DOMAIN}
+      SSL_EMAIL: ${SSL_EMAIL}
     depends_on:
       - mysql
   mysql:

--- a/docker-compose-prod/docker-compose.yaml
+++ b/docker-compose-prod/docker-compose.yaml
@@ -25,6 +25,8 @@ services:
       DB_PASS: ${DB_PASS}
       SSL_DOMAIN: ${SSL_DOMAIN}
       SSL_EMAIL: ${SSL_EMAIL}
+    volumes:
+      - ssl-key:/etc/nginx/ssl_key
     depends_on:
       - mysql
   mysql:
@@ -42,4 +44,9 @@ volumes:
     driver_opts:
       type: none
       device: ${PWD}/mysql_data
+      o: bind
+  ssl-key:
+    driver_opts:
+      type: none
+      device: ${PWD}/ssl_key
       o: bind

--- a/docker-compose-prod/docker-compose.yaml
+++ b/docker-compose-prod/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
       context: ./nginx-uwsgi-py3
       args:
         GIT_URI: ${GIT_URI}
+        SSL_DOMAIN: ${SSL_DOMAIN}
+        SSL_EMAIL: ${SSL_EMAIL}
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
+++ b/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
@@ -44,6 +44,19 @@ RUN echo ${GIT_URI}
 RUN ls -R /var/www/html
 RUN git clone ${GIT_URI} /var/www/html/app/
 
+# letsencryptのインストール
+RUN git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
+
+# letsencryptでSSL鍵を生成(ドメインの認証をするために、独自のスタンドアローンなHTTPサーバを内部的に起動する)
+ARG SSL_DOMAIN
+ARG SSL_EMAIL
+RUN /home/letsencrypt/letsencrypt-auto certonly --standalone --non-interactive --agree-tos -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
+
+# SSL鍵の配置
+RUN cp /etc/letsencrypt/live/${SSL_DOMAIN}/fullchain.pem /etc/nginx/fullchain.pem
+RUN cp /etc/letsencrypt/live/${SSL_DOMAIN}/privkey.pem /etc/nginx/privkey.pem
+RUN chmod 400 /etc/nginx/privkey.pem
+
 # WEBアプリのデプロイ先
 WORKDIR /var/www/html/app/
 

--- a/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
+++ b/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
@@ -73,4 +73,4 @@ ADD conf/default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 EXPOSE 443
 
-CMD /bin/bash -x /tmp/start.sh > /tmp/start.sh.log
+CMD /bin/bash -x /tmp/start.sh >& /tmp/start.sh.log

--- a/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
+++ b/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
@@ -65,12 +65,22 @@ ADD ./sh/start.sh /tmp/start.sh
 # nginxの設定関係
 COPY conf/nginx.conf /etc/nginx/nginx.conf
 ADD conf/default.conf /etc/nginx/conf.d/default.conf
-ADD ssl_pem/fullchain.pem /etc/nginx/fullchain.pem
-ADD ssl_pem/privkey.pem /etc/nginx/privkey.pem
-RUN chmod 400 /etc/nginx/privkey.pem
 
 # ポートの公開
 EXPOSE 80
 EXPOSE 443
+
+# letsencryptでSSL鍵を生成＆配置(ドメインの認証をするために、一度nginxの起動が必要)
+ARG SSL_DOMAIN
+ARG SSL_EMAIL
+RUN /etc/init.d/nginx start
+RUN git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
+RUN /home/letsencrypt/letsencrypt-auto --help -y
+RUN /home/letsencrypt/letsencrypt-auto certonly --non-interactive --agree-tos --webroot -w /var/www/html/app/ -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
+RUN /etc/init.d/nginx stop
+# SSL鍵の配置
+RUN cp /etc/letsencrypt/live/www.tatatatask.work/fullchain.pem /etc/nginx/fullchain.pem
+RUN cp /etc/letsencrypt/live/www.tatatatask.work/privkey.pem /etc/nginx/privkey.pem
+RUN chmod 400 /etc/nginx/privkey.pem
 
 CMD /bin/bash /tmp/start.sh

--- a/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
+++ b/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
@@ -70,4 +70,4 @@ ADD conf/default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 EXPOSE 443
 
-CMD /bin/bash /tmp/start.sh
+CMD /bin/bash /tmp/start.sh > /tmp/start.sh.log

--- a/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
+++ b/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
@@ -70,4 +70,4 @@ ADD conf/default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 EXPOSE 443
 
-CMD /bin/bash /tmp/start.sh > /tmp/start.sh.log
+CMD /bin/bash -x /tmp/start.sh > /tmp/start.sh.log

--- a/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
+++ b/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
@@ -70,17 +70,4 @@ ADD conf/default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 EXPOSE 443
 
-# letsencryptでSSL鍵を生成＆配置(ドメインの認証をするために、一度nginxの起動が必要)
-ARG SSL_DOMAIN
-ARG SSL_EMAIL
-RUN /etc/init.d/nginx start
-RUN git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
-RUN /home/letsencrypt/letsencrypt-auto --help -y
-RUN /home/letsencrypt/letsencrypt-auto certonly --non-interactive --agree-tos --webroot -w /var/www/html/app/ -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
-RUN /etc/init.d/nginx stop
-# SSL鍵の配置
-RUN cp /etc/letsencrypt/live/www.tatatatask.work/fullchain.pem /etc/nginx/fullchain.pem
-RUN cp /etc/letsencrypt/live/www.tatatatask.work/privkey.pem /etc/nginx/privkey.pem
-RUN chmod 400 /etc/nginx/privkey.pem
-
 CMD /bin/bash /tmp/start.sh

--- a/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
+++ b/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
@@ -47,6 +47,10 @@ RUN git clone ${GIT_URI} /var/www/html/app/
 # letsencryptのインストール
 RUN git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
 
+# ポートの公開
+EXPOSE 80
+EXPOSE 443
+
 # letsencryptでSSL鍵を生成(ドメインの認証をするために、独自のスタンドアローンなHTTPサーバを内部的に起動する)
 ARG SSL_DOMAIN
 ARG SSL_EMAIL
@@ -78,9 +82,5 @@ ADD ./sh/start.sh /tmp/start.sh
 # nginxの設定関係
 COPY conf/nginx.conf /etc/nginx/nginx.conf
 ADD conf/default.conf /etc/nginx/conf.d/default.conf
-
-# ポートの公開
-EXPOSE 80
-EXPOSE 443
 
 CMD /bin/bash -x /tmp/start.sh > /tmp/start.sh.log

--- a/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
+++ b/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
@@ -73,4 +73,4 @@ ADD conf/default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 EXPOSE 443
 
-CMD /bin/bash -x /tmp/start.sh >& /tmp/start.sh.log
+CMD /bin/bash -x /tmp/start.sh > /tmp/start.sh.log 2>&1

--- a/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
+++ b/docker-compose-prod/nginx-uwsgi-py3/Dockerfile
@@ -47,20 +47,6 @@ RUN git clone ${GIT_URI} /var/www/html/app/
 # letsencryptのインストール
 RUN git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
 
-# ポートの公開
-EXPOSE 80
-EXPOSE 443
-
-# letsencryptでSSL鍵を生成(ドメインの認証をするために、独自のスタンドアローンなHTTPサーバを内部的に起動する)
-ARG SSL_DOMAIN
-ARG SSL_EMAIL
-RUN /home/letsencrypt/letsencrypt-auto certonly --standalone --non-interactive --agree-tos -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
-
-# SSL鍵の配置
-RUN cp /etc/letsencrypt/live/${SSL_DOMAIN}/fullchain.pem /etc/nginx/fullchain.pem
-RUN cp /etc/letsencrypt/live/${SSL_DOMAIN}/privkey.pem /etc/nginx/privkey.pem
-RUN chmod 400 /etc/nginx/privkey.pem
-
 # WEBアプリのデプロイ先
 WORKDIR /var/www/html/app/
 
@@ -82,5 +68,9 @@ ADD ./sh/start.sh /tmp/start.sh
 # nginxの設定関係
 COPY conf/nginx.conf /etc/nginx/nginx.conf
 ADD conf/default.conf /etc/nginx/conf.d/default.conf
+
+# ポートの公開
+EXPOSE 80
+EXPOSE 443
 
 CMD /bin/bash -x /tmp/start.sh > /tmp/start.sh.log

--- a/docker-compose-prod/nginx-uwsgi-py3/conf/default.conf
+++ b/docker-compose-prod/nginx-uwsgi-py3/conf/default.conf
@@ -25,8 +25,8 @@ server {
 
     ssl on;
     ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
-    ssl_certificate     /etc/nginx/fullchain.pem;
-    ssl_certificate_key /etc/nginx/privkey.pem;
+    ssl_certificate     /etc/nginx/ssl_key/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl_key/privkey.pem;
 
     location = /favicon.ico {
         empty_gif;

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -15,6 +15,8 @@ cp /etc/letsencrypt/live/www.tatatatask.work/fullchain.pem /etc/nginx/fullchain.
 cp /etc/letsencrypt/live/www.tatatatask.work/privkey.pem /etc/nginx/privkey.pem
 chmod 400 /etc/nginx/privkey.pem
 
+/etc/init.d/nginx restart
+
 # migrationsの再構築
 cd /var/www/html/app
 rm -rf migrations

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -5,6 +5,14 @@
 
 export LANG=ja_JP.UTF-8
 
+# letsencryptでSSL鍵を生成(ドメインの認証をするために、独自のスタンドアローンなHTTPサーバを内部的に起動する)
+/home/letsencrypt/letsencrypt-auto certonly --standalone --non-interactive --agree-tos -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
+
+# SSL鍵の配置
+cp /etc/letsencrypt/live/${SSL_DOMAIN}/fullchain.pem /etc/nginx/fullchain.pem
+cp /etc/letsencrypt/live/${SSL_DOMAIN}/privkey.pem /etc/nginx/privkey.pem
+chmod 400 /etc/nginx/privkey.pem
+
 # nginx起動
 /etc/init.d/nginx start
 

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 # エラー時中断するように、などの設定
-set -eux
+#set -eux
 
 export LANG=ja_JP.UTF-8
 
-FULLCHAIN_DEST=/etc/nginx/fullchain.pem
-PRIVKEY_DEST=/etc/nginx/privkey.pem
+FULLCHAIN_DEST=/etc/nginx/ssl_key/fullchain.pem
+PRIVKEY_DEST=/etc/nginx/ssl_key/privkey.pem
 
 if [ ! -f ${FULLCHAIN_DEST} ] || [ `date +%Y%m%d -r ${FULLCHAIN_DEST}` -lt `date +%Y%m%d -d '30 day ago'` ]; then
     # letsencryptでSSL鍵を生成(ドメインの認証をするために、独自のスタンドアローンなHTTPサーバを内部的に起動する)

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -16,7 +16,7 @@ chmod 400 /etc/nginx/privkey.pem
 # nginx起動
 /etc/init.d/nginx start
 
-/etc/init.d/nginx restart
+/home/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/html/app --non-interactive --agree-tos --force-renewal -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
 
 # migrationsの再構築
 cd /var/www/html/app

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -15,14 +15,14 @@ if [ ! -f ${FULLCHAIN_DEST} ] || [ `date +%Y%m%d -r ${FULLCHAIN_DEST}` -lt `date
     # SSL鍵の配置
     cp /etc/letsencrypt/live/${SSL_DOMAIN}/fullchain.pem ${FULLCHAIN_DEST}
     cp /etc/letsencrypt/live/${SSL_DOMAIN}/privkey.pem ${PRIVKEY_DEST}
-    chmod 400 /etc/nginx/privkey.pem
+    chmod 400 ${PRIVKEY_DEST}
 fi
 
 # nginx起動
 /etc/init.d/nginx start
 
 # nginx起動後は80番がnginxに使われるので、Standaloneからwebrootへ変更して更新する
-/home/letsencrypt/letsencrypt-auto renew --webroot -w /var/www/html/app --non-interactive --agree-tos --force-renewal -d ${SSL_DOMAIN} --email ${SSL_EMAIL} --post-hook "cp /etc/letsencrypt/live/${SSL_DOMAIN}/fullchain.pem ${FULLCHAIN_DEST};cp /etc/letsencrypt/live/${SSL_DOMAIN}/privkey.pem ${PRIVKEY_DEST};chmod 400 /etc/nginx/privkey.pem;/etc/init.d/nginx restart"
+/home/letsencrypt/letsencrypt-auto renew --webroot -w /var/www/html/app --non-interactive --agree-tos --force-renewal -d ${SSL_DOMAIN} --email ${SSL_EMAIL} --post-hook "cp /etc/letsencrypt/live/${SSL_DOMAIN}/fullchain.pem ${FULLCHAIN_DEST};cp /etc/letsencrypt/live/${SSL_DOMAIN}/privkey.pem ${PRIVKEY_DEST};chmod 400 ${PRIVKEY_DEST};/etc/init.d/nginx restart"
 
 # migrationsの再構築
 cd /var/www/html/app

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -8,15 +8,6 @@ export LANG=ja_JP.UTF-8
 # nginx起動
 /etc/init.d/nginx start
 
-# letsencryptでSSL鍵を生成(ドメインの認証をするために、一度nginxの起動が必要)
-git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
-yes yes | /home/letsencrypt/letsencrypt-auto certonly --non-interactive --agree-tos --webroot -w /var/www/html/app/ -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
-
-# SSL鍵の配置
-cp /etc/letsencrypt/live/www.tatatatask.work/fullchain.pem /etc/nginx/fullchain.pem
-cp /etc/letsencrypt/live/www.tatatatask.work/privkey.pem /etc/nginx/privkey.pem
-chmod 400 /etc/nginx/privkey.pem
-
 /etc/init.d/nginx restart
 
 # migrationsの再構築

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -7,7 +7,7 @@ export LANG=ja_JP.UTF-8
 
 # letsencryptでSSL鍵を生成(ドメインの認証をするために、一度nginxの起動が必要)
 git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
-/home/letsencrypt/letsencrypt-auto certonly --non-interactive --agree-tos --webroot -w /var/www/html/app/ -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
+echo yes | /home/letsencrypt/letsencrypt-auto certonly --non-interactive --agree-tos --webroot -w /var/www/html/app/ -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
 
 # SSL鍵の配置
 cp /etc/letsencrypt/live/www.tatatatask.work/fullchain.pem /etc/nginx/fullchain.pem

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -5,9 +5,18 @@ export LANG=ja_JP.UTF-8
 # nginx起動
 /etc/init.d/nginx start
 
-cd /var/www/html/app
+# letsencryptでSSL鍵を生成(ドメインの認証をするために、一度nginxの起動が必要)
+git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
+/home/letsencrypt/letsencrypt-auto --help -y
+/home/letsencrypt/letsencrypt-auto certonly --non-interactive --agree-tos --webroot -w /var/www/html/app/ -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
+
+# SSL鍵の配置
+cp /etc/letsencrypt/live/www.tatatatask.work/fullchain.pem /etc/nginx/fullchain.pem
+cp /etc/letsencrypt/live/www.tatatatask.work/privkey.pem /etc/nginx/privkey.pem
+chmod 400 /etc/nginx/privkey.pem
 
 # migrationsの再構築
+cd /var/www/html/app
 rm -rf migrations
 FLASK_APP=main.py pipenv run flask db init
 FLASK_APP=main.py pipenv run flask db migrate

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -7,7 +7,7 @@ export LANG=ja_JP.UTF-8
 
 # letsencryptでSSL鍵を生成(ドメインの認証をするために、一度nginxの起動が必要)
 git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
-echo yes | /home/letsencrypt/letsencrypt-auto certonly --non-interactive --agree-tos --webroot -w /var/www/html/app/ -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
+yes yes | /home/letsencrypt/letsencrypt-auto certonly --non-interactive --agree-tos --webroot -w /var/www/html/app/ -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
 
 # SSL鍵の配置
 cp /etc/letsencrypt/live/www.tatatatask.work/fullchain.pem /etc/nginx/fullchain.pem

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -7,7 +7,6 @@ export LANG=ja_JP.UTF-8
 
 # letsencryptでSSL鍵を生成(ドメインの認証をするために、一度nginxの起動が必要)
 git clone https://github.com/letsencrypt/letsencrypt.git /home/letsencrypt
-/home/letsencrypt/letsencrypt-auto --help -y
 /home/letsencrypt/letsencrypt-auto certonly --non-interactive --agree-tos --webroot -w /var/www/html/app/ -d ${SSL_DOMAIN} --email ${SSL_EMAIL}
 
 # SSL鍵の配置

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # エラー時中断するように、などの設定
-set -eux
+# set -eux
 
 export LANG=ja_JP.UTF-8
 

--- a/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
+++ b/docker-compose-prod/nginx-uwsgi-py3/sh/start.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# エラー時中断するように、などの設定
+set -eux
+
 export LANG=ja_JP.UTF-8
 
 # nginx起動

--- a/docker-compose-prod/ssl_key/.gitignore
+++ b/docker-compose-prod/ssl_key/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
#12 の件があるが、とりあえずSSL鍵の更新ができるようにはなったのでマージしてしまおうかと。

- `docker-compose up -d` する度にSSL鍵を更新する
- 取得した鍵は`docker-compose-prod/ssl_key/` にローカルディスクとして保管される
  - SSL鍵置き場のフォルダをローカルディスクに逃がして、マウントする形式に変更した

